### PR TITLE
Fixed availability zone bug in VPC module

### DIFF
--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -11,11 +11,15 @@ resource "aws_vpc" "vpc" {
 resource "aws_subnet" "public_subnet" {
   cidr_block = var.public_cidr_range
   vpc_id = aws_vpc.vpc.id
+
+  availability_zone = var.availability_zones[0]
 }
 
 resource "aws_subnet" "second_public_subnet" {
   cidr_block = var.second_public_cidr_range
   vpc_id = aws_vpc.vpc.id
+
+  availability_zone = var.availability_zones[1]
 }
 
 resource "aws_route_table" "public_route_table" {
@@ -47,11 +51,15 @@ resource "aws_internet_gateway" "internet_access" {
 resource "aws_subnet" "private_subnet" {
   cidr_block = var.private_cidr_range
   vpc_id = aws_vpc.vpc.id
+
+  availability_zone = var.availability_zones[0]
 }
 
 resource "aws_subnet" "second_private_subnet" {
   cidr_block = var.second_private_cidr_range
   vpc_id = aws_vpc.vpc.id
+
+  availability_zone = var.availability_zones[1]
 }
 
 resource "aws_route_table" "private_route_table" {

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -8,13 +8,13 @@ variable "vpc_cidr" {
 }
 
 variable "availability_zones" {
-  description = "List of availability zones to deploy subnets to."
+  description = "List of availability zones to deploy subnets to. Must be at least two."
   type = list(string)
 
-  validation {
-    condition     = length(var.availability_zones) > 1
-    error_message = "At least two availability zones must be selected."
-  }
+//  validation {
+//    condition     = length(var.availability_zones) > 1
+//    error_message = "At least two availability zones must be selected."
+//  }
 }
 
 variable "public_cidr_range" {

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -7,6 +7,16 @@ variable "vpc_cidr" {
   description = "CIDR range of the VPC."
 }
 
+variable "availability_zones" {
+  description = "List of availability zones to deploy subnets to."
+  type = list(string)
+
+  validation {
+    condition     = length(var.availability_zones) > 1
+    error_message = "At least two availability zones must be selected."
+  }
+}
+
 variable "public_cidr_range" {
   description = "CIDR range of the public subnet."
 }


### PR DESCRIPTION
The subnets in the VPC module had no specific availability zones, meaning that sometimes they were deployed in the same zone.

This causes a problem with certain resources which rely on the subnets, for example an ALB, where the subnets must be in different availability zones.

This merge request adds an input to the module: a list of availability zones.

I have also added some terraform to validate that the list contains at least two items, although it is commented out currently as that feature is experimental currently.