### PR TITLE
Split VPC module into two modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Creates resources required for VPC networking.
 - VPC
 - Two private subnets
 - Two public subnets
-- NAT Gateway
 - Internet Gateway
 
 ```hcl-terraform
@@ -65,6 +64,10 @@ Outputs:
 - vpc_id
 - public_subnets (Subnet IDs)
 - private_subnets (Subnet IDs)
+
+## vpc_with_nat
+Creates the same as "vpc" with the addition of a NAT Gateway.<br>
+NAT Gateways cost money, so unless you require it use "vpc" instead.
 
 ## vpc_lambda
 Creates a Lambda hosted within a VPC.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ Outputs:
 Creates the same as "vpc" with the addition of a NAT Gateway.<br>
 NAT Gateways cost money, so unless you require it use "vpc" instead.
 
+```hcl-terraform
+module "vpc" {
+  source = "github.com/will-goodman/aws-terraform-modules//vpc_with_nat"
+  
+  vpc_name = //Name to assign to the VPC.
+  
+  vpc_cidr = //CIDR range of the VPC.
+  availability_zones = //List of availability zones to deploy subnets to. Must be at least two.
+  public_cidr_range = //CIDR range of the public subnet.
+  second_public_cidr_range = //CIDR range of the second public subnet.
+  private_cidr_range = //CIDR range of the private subnet.
+  second_private_cidr_range = //CIDR range of the second private subnet.
+}
+```
+
 ## vpc_lambda
 Creates a Lambda hosted within a VPC.
 - Lambda

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -60,22 +60,3 @@ resource "aws_subnet" "second_private_subnet" {
 
   availability_zone = var.availability_zones[1]
 }
-
-resource "aws_route_table" "private_route_table" {
-  vpc_id = aws_vpc.vpc.id
-}
-
-resource "aws_route_table_association" "private_association" {
-  route_table_id = aws_route_table.private_route_table.id
-  subnet_id = aws_subnet.private_subnet.id
-}
-
-resource "aws_route_table_association" "second_private_association" {
-  route_table_id = aws_route_table.private_route_table.id
-  subnet_id = aws_subnet.second_private_subnet.id
-}
-
-resource "aws_route" "private_route" {
-  route_table_id = aws_route_table.private_route_table.id
-  destination_cidr_block = "0.0.0.0/0"
-}

--- a/vpc_with_nat/main.tf
+++ b/vpc_with_nat/main.tf
@@ -1,5 +1,6 @@
+
 resource "aws_vpc" "vpc" {
-  cidr_block = var.vpc_cidr
+  cidr_block       = var.vpc_cidr
 
   tags = {
     Name = var.vpc_name
@@ -78,4 +79,14 @@ resource "aws_route_table_association" "second_private_association" {
 resource "aws_route" "private_route" {
   route_table_id = aws_route_table.private_route_table.id
   destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id = aws_nat_gateway.nat_gateway.id
+}
+
+resource "aws_eip" "nat_eip" {
+  vpc = true
+}
+
+resource "aws_nat_gateway" "nat_gateway" {
+  allocation_id = aws_eip.nat_eip.id
+  subnet_id = aws_subnet.public_subnet.id
 }

--- a/vpc_with_nat/outputs.tf
+++ b/vpc_with_nat/outputs.tf
@@ -1,0 +1,12 @@
+
+output "vpc_id" {
+  value = aws_vpc.vpc.id
+}
+
+output "public_subnets" {
+  value = [aws_subnet.public_subnet.id, aws_subnet.second_public_subnet.id]
+}
+
+output "private_subnets" {
+  value = [aws_subnet.private_subnet.id, aws_subnet.second_private_subnet.id]
+}

--- a/vpc_with_nat/variables.tf
+++ b/vpc_with_nat/variables.tf
@@ -1,0 +1,35 @@
+
+variable "vpc_name" {
+  description = "Name to assign to the VPC."
+}
+
+variable "vpc_cidr" {
+  description = "CIDR range of the VPC."
+}
+
+variable "availability_zones" {
+  description = "List of availability zones to deploy subnets to. Must be at least two."
+  type = list(string)
+
+  // Feature still in experimentation
+//  validation {
+//    condition     = length(var.availability_zones) > 1
+//    error_message = "At least two availability zones must be selected."
+//  }
+}
+
+variable "public_cidr_range" {
+  description = "CIDR range of the public subnet."
+}
+
+variable "second_public_cidr_range" {
+  description = "CIDR range of the second public subnet."
+}
+
+variable "private_cidr_range" {
+  description = "CIDR range of the private subnet."
+}
+
+variable "second_private_cidr_range" {
+  description = "CIDR range of the second private subnet."
+}


### PR DESCRIPTION
NAT Gateways cost money and are not always required. Split the VPC module into two modules; one with NAT Gateway and one without.